### PR TITLE
Fix module import string

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "type": "git",
     "url": "https://github.com/kelsonpw/react-chrome-extension-router.git"
   },
-  "module": "dist/react-chrome-extension-router-v1.esm.js",
+  "module": "dist/react-chrome-extension-router.esm.js",
   "devDependencies": {
     "@testing-library/dom": "^7.28.1",
     "@testing-library/react": "^9.4.0",


### PR DESCRIPTION
Changed the "module" in package.json to allows Vite to bundle correctly.

Issue:
https://github.com/kelsonpw/react-chrome-extension-router/issues/27